### PR TITLE
[TMP] Support container building

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN ["make", "build-within-docker"]
 
 ########################################################
 
-FROM photonos-docker-local.artifactory.eng.vmware.com/photon4:4.0-GA
+FROM photon:4.0
 RUN tdnf install -y xfsprogs
 # udev is to get scsi_id, e2fsprogs is for mkfs.ext4
 RUN tdnf install -y e2fsprogs

--- a/Makefile
+++ b/Makefile
@@ -12,11 +12,7 @@ build-within-docker:
 	go build -ldflags "-X github.com/vmware/cloud-director-named-disk-csi-driver/version.Version=$(version)" -o /build/vcloud/cloud-director-named-disk-csi-driver cmd/csi/main.go
 
 csi: $(GO_CODE)
-	docker build -f Dockerfile . -t cloud-director-named-disk-csi-driver:$(version)
-	docker tag cloud-director-named-disk-csi-driver:$(version) $(REGISTRY)/cloud-director-named-disk-csi-driver:$(version)
-	docker tag cloud-director-named-disk-csi-driver:$(version) $(REGISTRY)/cloud-director-named-disk-csi-driver:$(version).$(GITCOMMIT)
-	docker push $(REGISTRY)/cloud-director-named-disk-csi-driver:$(version)
-	touch out/$@
+	docker buildx build --platform linux/amd64 -f Dockerfile . -t quay.io/giantswarm/csi-cloud-director:1.2.0.$(GITCOMMIT)
 
 prod: csi
 	sed -e "s/\.__GIT_COMMIT__//g" manifests/csi-controller.yaml.template > manifests/csi-controller.yaml


### PR DESCRIPTION
This PR documents how to get a release for CSI.

Current branch consists of
- 1.3.z branch as the base. Points 1.3.2 at the moment.
- Cherry-picked https://github.com/vmware/cloud-director-named-disk-csi-driver/pull/174. This is already merged master. Will be part of next releases. 
- Container image-building logic for this hot fix. 